### PR TITLE
feat: 텍스트 입력 번역 기능 추가

### DIFF
--- a/src/background/messageHandler.ts
+++ b/src/background/messageHandler.ts
@@ -18,6 +18,10 @@ export async function handleMessage(
     return await handleTranslation();
   }
 
+  if (message.type === "TRANSLATE_TEXT") {
+    return await handleTextTranslation(message.text);
+  }
+
   return { type: "STATUS", status: "error", error: "Unknown message" };
 }
 
@@ -60,6 +64,35 @@ async function handleTranslation(): Promise<BackgroundResponse> {
     return {
       type: "STATUS",
       status: "error",
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+async function handleTextTranslation(
+  text: string,
+): Promise<BackgroundResponse> {
+  try {
+    if (!text.trim()) {
+      return {
+        type: "TRANSLATED_TEXT",
+        text: "",
+        error: "텍스트를 입력해주세요",
+      };
+    }
+
+    const detectedLang = await detectLanguage(text);
+
+    if (detectedLang === "ko") {
+      return { type: "TRANSLATED_TEXT", text, error: "이미 한국어입니다" };
+    }
+
+    const translated = await translate(text, detectedLang);
+    return { type: "TRANSLATED_TEXT", text: translated };
+  } catch (error) {
+    return {
+      type: "TRANSLATED_TEXT",
+      text: "",
       error: error instanceof Error ? error.message : "Unknown error",
     };
   }

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -2,13 +2,24 @@ import { useState } from "react";
 import type { TranslationStatus, ModelType } from "../shared/types";
 import type { BackgroundResponse } from "../shared/messages";
 
+type TabType = "page" | "text";
+
 export function App() {
+  const [activeTab, setActiveTab] = useState<TabType>("page");
+
+  // 페이지 번역 상태
   const [status, setStatus] = useState<TranslationStatus>("idle");
   const [downloadProgress, setDownloadProgress] = useState<{
     model: ModelType;
     progress: number;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // 텍스트 번역 상태
+  const [inputText, setInputText] = useState("");
+  const [translatedText, setTranslatedText] = useState("");
+  const [textError, setTextError] = useState<string | null>(null);
+  const [isTextTranslating, setIsTextTranslating] = useState(false);
 
   const handleTranslate = async () => {
     setStatus("detecting");
@@ -24,83 +35,215 @@ export function App() {
     }
   };
 
+  const handleTextTranslate = async () => {
+    setIsTextTranslating(true);
+    setTextError(null);
+    setTranslatedText("");
+
+    const response: BackgroundResponse = await chrome.runtime.sendMessage({
+      type: "TRANSLATE_TEXT",
+      text: inputText,
+    });
+
+    if (response.type === "TRANSLATED_TEXT") {
+      setTranslatedText(response.text);
+      if (response.error) setTextError(response.error);
+    }
+
+    setIsTextTranslating(false);
+  };
+
   const isLoading =
     status === "detecting" ||
     status === "downloading" ||
     status === "translating";
 
-  return (
-    <div style={{ width: 280, padding: 16, fontFamily: "system-ui" }}>
-      <h2 style={{ margin: "0 0 16px", fontSize: 18 }}>HanTranslate.ai</h2>
+  const tabStyle = (isActive: boolean) => ({
+    flex: 1,
+    padding: "8px 12px",
+    fontSize: 13,
+    fontWeight: 500,
+    border: "none",
+    borderBottom: isActive ? "2px solid #4285f4" : "2px solid transparent",
+    background: "transparent",
+    color: isActive ? "#4285f4" : "#666",
+    cursor: "pointer",
+  });
 
-      {/* 다운로드 진행률 */}
-      {downloadProgress && (
-        <div style={{ marginBottom: 12 }}>
-          <div style={{ fontSize: 12, color: "#666", marginBottom: 4 }}>
-            {downloadProgress.model === "detector" ? "언어 감지" : "번역"} 모델
-            다운로드 중...
-          </div>
-          <div style={{ background: "#eee", borderRadius: 4, height: 8 }}>
-            <div
+  return (
+    <div style={{ width: 280, fontFamily: "system-ui" }}>
+      <h2 style={{ margin: "16px 16px 12px", fontSize: 18 }}>
+        HanTranslate.ai
+      </h2>
+
+      {/* 탭 */}
+      <div style={{ display: "flex", borderBottom: "1px solid #eee" }}>
+        <button
+          style={tabStyle(activeTab === "page")}
+          onClick={() => setActiveTab("page")}
+        >
+          페이지 번역
+        </button>
+        <button
+          style={tabStyle(activeTab === "text")}
+          onClick={() => setActiveTab("text")}
+        >
+          텍스트 번역
+        </button>
+      </div>
+
+      <div style={{ padding: 16 }}>
+        {activeTab === "page" && (
+          <>
+            {/* 다운로드 진행률 */}
+            {downloadProgress && (
+              <div style={{ marginBottom: 12 }}>
+                <div style={{ fontSize: 12, color: "#666", marginBottom: 4 }}>
+                  {downloadProgress.model === "detector" ? "언어 감지" : "번역"}{" "}
+                  모델 다운로드 중...
+                </div>
+                <div style={{ background: "#eee", borderRadius: 4, height: 8 }}>
+                  <div
+                    style={{
+                      background: "#4285f4",
+                      borderRadius: 4,
+                      height: "100%",
+                      width: `${downloadProgress.progress * 100}%`,
+                      transition: "width 0.2s",
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* 상태 메시지 */}
+            {status === "completed" && (
+              <div
+                style={{
+                  padding: 8,
+                  background: "#e8f5e9",
+                  borderRadius: 4,
+                  marginBottom: 12,
+                  fontSize: 14,
+                }}
+              >
+                번역 완료
+              </div>
+            )}
+            {error && (
+              <div
+                style={{
+                  padding: 8,
+                  background: "#ffebee",
+                  borderRadius: 4,
+                  marginBottom: 12,
+                  fontSize: 14,
+                  color: "#c62828",
+                }}
+              >
+                {error}
+              </div>
+            )}
+
+            {/* 번역 버튼 */}
+            <button
+              onClick={handleTranslate}
+              disabled={isLoading}
               style={{
-                background: "#4285f4",
+                width: "100%",
+                padding: "10px 16px",
+                fontSize: 14,
+                fontWeight: 500,
+                border: "none",
+                borderRadius: 6,
+                background: isLoading ? "#ccc" : "#4285f4",
+                color: "white",
+                cursor: isLoading ? "not-allowed" : "pointer",
+              }}
+            >
+              {isLoading ? "번역 중..." : "이 페이지 번역하기"}
+            </button>
+          </>
+        )}
+
+        {activeTab === "text" && (
+          <>
+            {/* 입력 영역 */}
+            <textarea
+              value={inputText}
+              onChange={(e) => setInputText(e.target.value)}
+              placeholder="번역할 텍스트를 입력하세요"
+              style={{
+                width: "100%",
+                height: 80,
+                padding: 8,
+                fontSize: 13,
+                border: "1px solid #ddd",
                 borderRadius: 4,
-                height: "100%",
-                width: `${downloadProgress.progress * 100}%`,
-                transition: "width 0.2s",
+                resize: "none",
+                boxSizing: "border-box",
               }}
             />
-          </div>
-        </div>
-      )}
 
-      {/* 상태 메시지 */}
-      {status === "completed" && (
-        <div
-          style={{
-            padding: 8,
-            background: "#e8f5e9",
-            borderRadius: 4,
-            marginBottom: 12,
-            fontSize: 14,
-          }}
-        >
-          번역 완료
-        </div>
-      )}
-      {error && (
-        <div
-          style={{
-            padding: 8,
-            background: "#ffebee",
-            borderRadius: 4,
-            marginBottom: 12,
-            fontSize: 14,
-            color: "#c62828",
-          }}
-        >
-          {error}
-        </div>
-      )}
+            {/* 번역 버튼 */}
+            <button
+              onClick={handleTextTranslate}
+              disabled={isTextTranslating || !inputText.trim()}
+              style={{
+                width: "100%",
+                padding: "10px 16px",
+                fontSize: 14,
+                fontWeight: 500,
+                border: "none",
+                borderRadius: 6,
+                marginTop: 8,
+                background:
+                  isTextTranslating || !inputText.trim() ? "#ccc" : "#4285f4",
+                color: "white",
+                cursor:
+                  isTextTranslating || !inputText.trim()
+                    ? "not-allowed"
+                    : "pointer",
+              }}
+            >
+              {isTextTranslating ? "번역 중..." : "번역하기"}
+            </button>
 
-      {/* 번역 버튼 */}
-      <button
-        onClick={handleTranslate}
-        disabled={isLoading}
-        style={{
-          width: "100%",
-          padding: "10px 16px",
-          fontSize: 14,
-          fontWeight: 500,
-          border: "none",
-          borderRadius: 6,
-          background: isLoading ? "#ccc" : "#4285f4",
-          color: "white",
-          cursor: isLoading ? "not-allowed" : "pointer",
-        }}
-      >
-        {isLoading ? "번역 중..." : "이 페이지 번역하기"}
-      </button>
+            {/* 에러 메시지 */}
+            {textError && (
+              <div
+                style={{
+                  padding: 8,
+                  background: "#ffebee",
+                  borderRadius: 4,
+                  marginTop: 12,
+                  fontSize: 14,
+                  color: "#c62828",
+                }}
+              >
+                {textError}
+              </div>
+            )}
+
+            {/* 번역 결과 */}
+            {translatedText && !textError && (
+              <div
+                style={{
+                  marginTop: 12,
+                  padding: 8,
+                  background: "#f5f5f5",
+                  borderRadius: 4,
+                  fontSize: 13,
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                }}
+              >
+                {translatedText}
+              </div>
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -3,13 +3,15 @@ import type { TranslationStatus, ModelType } from "./types";
 // Popup → Background
 export type PopupMessage =
   | { type: "START_TRANSLATION" }
-  | { type: "GET_STATUS" };
+  | { type: "GET_STATUS" }
+  | { type: "TRANSLATE_TEXT"; text: string };
 
 // Background → Popup (응답)
 export type BackgroundResponse =
   | { type: "STATUS"; status: TranslationStatus; error?: string }
   | { type: "DOWNLOAD_PROGRESS"; model: ModelType; progress: number }
-  | { type: "LANGUAGE_DETECTED"; language: string };
+  | { type: "LANGUAGE_DETECTED"; language: string }
+  | { type: "TRANSLATED_TEXT"; text: string; error?: string };
 
 // Background → Content
 export type ContentMessage =


### PR DESCRIPTION
## 작업 내용

Closes #5

- 팝업 UI 상단에 탭 네비게이션 추가 (페이지 번역 / 텍스트 번역)
- 텍스트 입력 영역과 번역 버튼, 결과 출력 영역 구현
- `TRANSLATE_TEXT`, `TRANSLATED_TEXT` 메시지 타입 추가
- `handleTextTranslation` 핸들러 구현 (언어 감지 → 번역)
- 에러 처리: 빈 텍스트, 이미 한국어인 경우, API 에러

## 특이사항

- 기존 페이지 번역 기능은 첫 번째 탭에 그대로 유지
- 복잡한 UI 라이브러리 없이 인라인 스타일로 구현

## 기타

-
