### PR TITLE
chore: release-please의 PR 제목 패턴 변경

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
+  "pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## 🌱 관련 이슈
- close #16 

## 📌 작업 내용 및 특이사항
- `release-please-config.json`에 `pull-request-title-pattern` 설정 추가
- PR 제목 형식을 `chore(main): release x.x.x`에서 `chore: release x.x.x`로 변경
- 다음 릴리즈부터 새 패턴이 적용됨

## 📝 참고사항
- 기존 PR #15는 이전 설정으로 생성되어 `chore(main): release 0.2.0` 제목 유지
- 설정 변경 후 생성되는 릴리즈 PR부터 새 패턴 적용

## 📚 기타
-


<details>
<summary>CONTEXT.md 전체 내용</summary>

```markdown
# CONTEXT.md

## 작업 정보
- 이슈: #16 - ⚙️ release-please의 PR 제목 패턴 변경

## 요구사항

- `release-please-config.json` 파일에 `pull-request-title-pattern` 설정을 추가하여 PR 제목 형식을 변경
- 현재: `chore(main): release 0.2.0` (자동 생성된 PR #15의 제목)
- 변경 후: `chore: release 0.2.0`
- 설정 값: `"pull-request-title-pattern": "chore: release ${version}"`
- 위치: `/release-please-config.json` (루트 디렉토리)

## 구현 계획

(메인 에이전트가 작성 예정)

## 세션 기록

### 세션 #16 (2025-12-18)
**진행 내용**:
- 이슈 #16 생성/확인: release-please의 PR 제목 패턴 변경 작업
- 요구사항 구체화: `pull-request-title-pattern` 설정 추가
- 구현 완료: `release-please-config.json`에 설정 추가됨 (커밋 대기 중)
- (메인 에이전트가 업데이트 예정)

```
</details>
